### PR TITLE
Fix python 2->3 errors when using -r

### DIFF
--- a/rcw.py
+++ b/rcw.py
@@ -811,7 +811,7 @@ def create_source():
     # After this stage, all the RCW bits should be formatted with lsb on
     # the right side and msb on the left side to permit conversion into
     # a very long uint.
-    bitstring = ''.join(['{0:08b}'.format(ord(x)) for x in bitbytes])[::-1]
+    bitstring = ''.join(['{0:08b}'.format(x) for x in bitbytes])[::-1]
     bits = int(bitstring, 2)
 
     # Loop over all the known symbols

--- a/rcw.py
+++ b/rcw.py
@@ -779,19 +779,19 @@ def create_source():
         if pbiformat == 2:
             if binary[0:4] == preambletst:
                 # Convert the binary into a large integer
-                rcw = binary[8:8 + (size / 8)]
+                rcw = binary[8:8 + (size // 8)]
                 bitbytes = rcw
                 # We skip the checksum field
-                pbi = binary[8 + (size / 8) + 4:]
+                pbi = binary[8 + (size // 8) + 4:]
             else:
                 print('Weird binary RCW format!')
                 bitbytes = ''
         else:
             if binary[0:4] == preambletst:
                 # Convert the binary into a large integer
-                rcw = binary[8:8 + (size / 8)]
+                rcw = binary[8:8 + (size // 8)]
                 bitbytes = rcw
-                pbi = binary[8 + (size / 8):]
+                pbi = binary[8 + (size // 8):]
             else:
                 print('Weird binary RCW format!')
                 bitbytes = ''

--- a/rcw.py
+++ b/rcw.py
@@ -855,7 +855,7 @@ def create_source():
         l = len(pbi)
         # Deal reasonably with broken PBIs with, e.g., an extra LF
         # at the end
-        pbi += "\0\0\0"
+        pbi += b"\0\0\0"
         l += 3;
         l &= ~3;
         source += "\n.pbi\n"


### PR DESCRIPTION
Although 3f744d3 ("Convert to python3") converted most of rcw.py to
python 3, the -r path remains unconverted. This series addresses the
issues I ran into when using this flag.
