### PR TITLE
fix tag lf-6.6.52-2.2.0 - rcw parse error - XXX

### DIFF
--- a/lx2160asi/e100g1_split.rcw
+++ b/lx2160asi/e100g1_split.rcw
@@ -6,11 +6,11 @@
  *
  * board_info {
  *	serdes {
- *		/* Do not rely on the RCW protocol number, but rather read
- *		 * the protocol status registers (PSSR) for each SerDes
- *		 * block. That information will be used to enable/disable
- *		 * the appropriate MACs.
- *		 */
+ *		 // Do not rely on the RCW protocol number, but rather read
+ *		 // the protocol status registers (PSSR) for each SerDes
+ *		 // block. That information will be used to enable/disable
+ *		 // the appropriate MACs.
+ *		 //
  *		follow_hw_pssr;
  *	};
  * };


### PR DESCRIPTION
The syntax is not correct, it cannot be parsed. It'll lead to the error:
```
Traceback (most recent call last):
  File "lx2160aqds_rev2/../rcw.py", line 1075, in <module>
    parse_source_file(source)
  File "lx2160aqds_rev2/../rcw.py", line 520, in parse_source_file
    print('Error: unknown command', ' '.join(l2))
TypeError: sequence item 0: expected str instance, int found
make[2]: *** [../Makefile.inc:25: GGGG_CCCC_PPPP_PPPP_PPPP_PPPP_RR_13_3_2_e100g1_split/rcw_2000_700_2600_13_3_2_e100g1_split.bin] Error 1
```

Note that this commit does not belong to any branch on this repository, and may belong to a fork outside of the repository.