### PR TITLE
import new opcode: jumpc, jump, loadc

### DIFF
--- a/rcw.py
+++ b/rcw.py
@@ -960,7 +960,7 @@ def create_source():
                         i += 4
                         arg2 = struct.unpack(endianess + 'L', pbi[i:i+4])[0]
                         i += 4
-                        source += "loadcondition 0x%08x,0x%08x\n" % (arg1, arg2)
+                        source += "loadc 0x%08x,0x%08x\n" % (arg1, arg2)
                     elif cmd == 0x20:
                         source += "/* Disassemble not implemented for word 0x%08x */\n" % (word)
                     elif cmd == 0x22:
@@ -984,9 +984,9 @@ def create_source():
                     elif cmd == 0x82:
                         source += "wait 0x%08x\n" % (word & 0xffff)
                     elif cmd == 0x84:
-                        source += "/* Disassemble not implemented for word 0x%08x */\n" % (word)
+                        source += "/* Disassemble not implemented for word 0x%08x (jump) */\n" % (word)
                     elif cmd == 0x85:
-                        source += "/* Disassemble not implemented for word 0x%08x */\n" % (word)
+                        source += "/* Disassemble not implemented for word 0x%08x (jumpc) */\n" % (word)
                     elif cmd == 0x8f:
                         arg1 = struct.unpack(endianess + 'L', pbi[i:i+4])[0]
                         i += 4

--- a/rcw.py
+++ b/rcw.py
@@ -330,6 +330,34 @@ def build_pbi(lines):
             v2 = struct.pack(endianess + 'L', p2)
             subsection += v1
             subsection += v2
+        elif op == 'loadc':
+            if p1 == None or p2 == None:
+                print('Error: "loadc" instruction requires two parameters')
+                return ''
+            v1 = struct.pack(endianess + 'L', 0x80140000)
+            v2 = struct.pack(endianess + 'L', p1)
+            v3 = struct.pack(endianess + 'L', p2)
+            subsection += v1
+            subsection += v2
+            subsection += v3
+        elif op == 'jumpc':
+            if p1 == None or p2 == None:
+                print('Error: "jumpc" instruction requires two parameters')
+                return ''
+            v1 = struct.pack(endianess + 'L', 0x80850000)
+            v2 = struct.pack(endianess + 'L', p1)
+            v3 = struct.pack(endianess + 'L', p2)
+            subsection += v1
+            subsection += v2
+            subsection += v3
+        elif op == 'jump':
+            if p1 == None:
+                print('Error: "jump" instruction requires a parameter')
+                return ''
+            v1 = struct.pack(endianess + 'L', 0x80840000)
+            v2 = struct.pack(endianess + 'L', p1)
+            subsection += v1
+            subsection += v2
         elif op == 'awrite':
             if opsize == '.b5':
                 # altconfig write with B=5 (16 bytes)


### PR DESCRIPTION
The main work was done by Rabeeh from:
  https://github.com/SolidRun/lx2160a_build/blob/develop-ls-6.6.52-2.2.0/patches/rcw/0002-add-loadc-jumpc-and-jump-to-pbi-instructions.patch

Let's add some hints and typo fix for the disassemble case with a 2nd commit.

TODO: Based on some new use cases, some opcodes from the "Table 27. PBI Command Summary" of LX2160ARM.pdf could be added.

## Table 27. PBI Command Summary

### Block Copy Commands

| Command                 | Number | Size (bytes) | Description                                                                     |
|--------------------------|--------|--------------|---------------------------------------------------------------------------------|
| Block Copy               | 0x00   | 16           | Copy data from any of the available memory interfaces to a RAM                  |
| CCSR Write from Address  | 0x02   | -            | Update large number of CCSR registers consecutively from OCRAM, SPRAM           |

### Special Load Commands

| Command                         | Number | Size (bytes) | Description                                                                 |
|---------------------------------|--------|--------------|-----------------------------------------------------------------------------|
| Load RCW with Checksum           | 0x10   | 136          | Read Reset Configuration Word, perform simple 32-bit checksum, and update RCW registers |
| Load RCW w/o Checksum            | 0x11   | 136          | Read Reset Configuration Word and update RCW registers without checksum     |
| Load Alternate Configuration Window | 0x12 | 4           | Read in condition 14-bit base pointer for alternate configuration space     |
| Load Condition                   | 0x14   | 12           | Read in condition information for subsequent Conditional Jump               |
| Load Security Header             | 0x20   | 84           | Read CSF Header for authentication of PBI Image                             |
| Load Boot 1 CSF Header Ptr       | 0x22   | 8            | Read in a pointer to CSF header for authentication of Boot 1 code |
| CCSR Read, Modify and Write      | 0x42   | -            | Reads a CCSR register and changes (SET/CLEAR) its bits as per mask          |

### Control Commands

| Command           | Number | Size (bytes) | Description                                                   |
|-------------------|--------|--------------|---------------------------------------------------------------|
| Poll Short        | 0x80   | 16           | Poll a specified address for a specified value                 |
| Poll Long         | 0x81   | -            | Poll a specified address for a specified value                 |
| Wait              | 0x82   | 4            | Pause PBI sequence for specified number of iterations of a FOR loop |
| Jump              | 0x84   | 8            | Unconditional jump forward in PBI command sequence             |
| Jump Conditional  | 0x85   | 12           | Conditional jump forward in PBI boot sequence                  |
| CRC and Stop      | 0x8F   | 8            | Stop the PBI sequence and indicate the expected CRC value       |
| Stop              | 0xFF   | 8            | Stop the PBI sequence                                          |
